### PR TITLE
解决 [framework] CUICatalog: Invalid asset name supplied: '(null)' 问题

### DIFF
--- a/ZFSetting/View/ZFSettingCell.m
+++ b/ZFSetting/View/ZFSettingCell.m
@@ -53,7 +53,9 @@
             _switch = [[UISwitch alloc] init];
             _switch.on = item.switchOn;
             [_switch addTarget:self action:@selector(switchStatusChanged:) forControlEvents:UIControlEventValueChanged];
-        }
+		} else {
+			[_switch setOn:item.switchOn animated:YES];
+		}
         // 右边显示开关
         self.accessoryView = _switch;
         // 禁止选中

--- a/ZFSetting/View/ZFSettingCell.m
+++ b/ZFSetting/View/ZFSettingCell.m
@@ -53,9 +53,9 @@
             _switch = [[UISwitch alloc] init];
             _switch.on = item.switchOn;
             [_switch addTarget:self action:@selector(switchStatusChanged:) forControlEvents:UIControlEventValueChanged];
-		} else {
-			[_switch setOn:item.switchOn animated:YES];
-		}
+	} else {
+	    [_switch setOn:item.switchOn animated:YES];
+	}
         // 右边显示开关
         self.accessoryView = _switch;
         // 禁止选中

--- a/ZFSetting/View/ZFSettingCell.m
+++ b/ZFSetting/View/ZFSettingCell.m
@@ -42,7 +42,7 @@
 - (void)setItem:(ZFSettingItem *)item {
     _item = item;
     // 设置数据
-    self.imageView.image = [UIImage imageNamed:item.icon];
+	self.imageView.image = item.icon.length ? [UIImage imageNamed:item.icon] : nil;
     self.textLabel.text = item.title;
     if (item.type == ZFSettingItemTypeArrow) {
         self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;


### PR DESCRIPTION
为 icon 增加判断，解决 `[framework] CUICatalog: Invalid asset name supplied: '(null)'` 问题