### PR TITLE
修正 ZFSettingItemTypeArrow 类型 cell 刷新时没有把上一次的 accessoryView 清空导致的显示不正确问题

### DIFF
--- a/Setting/Setting/Base.lproj/LaunchScreen.storyboard
+++ b/Setting/Setting/Base.lproj/LaunchScreen.storyboard
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina4_0" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -13,18 +18,17 @@
                         <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ZFSetting" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="93z-60-bSy">
-                                <rect key="frame" x="214" y="276.5" width="172" height="48"/>
+                                <rect key="frame" x="75.5" y="260" width="169" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="40"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="93z-60-bSy" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="5sD-AJ-Plw"/>
                             <constraint firstItem="93z-60-bSy" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="W3H-4h-dDw"/>

--- a/ZFSetting/View/ZFSettingCell.m
+++ b/ZFSetting/View/ZFSettingCell.m
@@ -42,27 +42,24 @@
 - (void)setItem:(ZFSettingItem *)item {
     _item = item;
     // 设置数据
-	self.imageView.image = item.icon.length ? [UIImage imageNamed:item.icon] : nil;
+    self.imageView.image = item.icon.length ? [UIImage imageNamed:item.icon] : nil;
     self.textLabel.text = item.title;
-    if (item.type == ZFSettingItemTypeArrow) {
-        self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-        // 用默认的选中样式
-        self.selectionStyle = UITableViewCellSelectionStyleBlue;
-    } else if (item.type == ZFSettingItemTypeSwitch) {
+    if (item.type == ZFSettingItemTypeSwitch) {
         if (_switch == nil) {
             _switch = [[UISwitch alloc] init];
             _switch.on = item.switchOn;
             [_switch addTarget:self action:@selector(switchStatusChanged:) forControlEvents:UIControlEventValueChanged];
-	} else {
-	    [_switch setOn:item.switchOn animated:YES];
-	}
+        } else {
+            [_switch setOn:item.switchOn animated:YES];
+        }
         // 右边显示开关
         self.accessoryView = _switch;
         // 禁止选中
         self.selectionStyle = UITableViewCellSelectionStyleNone;
     } else {
-        // 什么也没有，清空右边显示的view
         self.accessoryView = nil;
+        self.accessoryType = item.type == ZFSettingItemTypeArrow ?
+        UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
         // 用默认的选中样式
         self.selectionStyle = UITableViewCellSelectionStyleBlue;
     }


### PR DESCRIPTION
修正 ZFSettingItemTypeArrow 类型 cell 刷新时没有把上一次的 accessoryView 清空导致的显示不正确问题。当有使用 ZFSettingItemTypeSwitch 类型的 cell 一起刷新数据时，就会导致还存留上一次的 switch 按钮。